### PR TITLE
Fix power-of-ten when closing number dialogs early

### DIFF
--- a/Utilities.flow
+++ b/Utilities.flow
@@ -49,7 +49,7 @@ int SelectNumber( int digitCount )
             }
             else
             {
-                number = number * PowF(10, -1 * i );
+                number = number / Pow(10, digitCount - i );
                 break;
             }
         }
@@ -80,7 +80,7 @@ float SelectFloat( float digitCount )
             }
             else
             {
-                number = number * PowF(10, -1 * i );
+                number = number / PowF(10, digitCount - i );
                 break;
             }
         }


### PR DESCRIPTION
There were two main issues: I was multiplying by a decimal float when I didn't need to, and I also was shifting the power-of-ten proportionally to the number of digits already entered, instead of inversely proportional.