### PR TITLE
Ingame ENV Adjustment Menu + EPL Preview Fixes 

### DIFF
--- a/ModMenu.flow
+++ b/ModMenu.flow
@@ -26,6 +26,9 @@ global int gEventMinor;
 global int gKfEventMajor;
 global int gKfEventMinor;
 
+global int CCParticle;
+global int CCParticleNumber; 
+
 void ModMenuDisplay()
 {
     ALL_ENABLE_SHARE_PLAY(); //Re-enables screen recording
@@ -62,23 +65,29 @@ void ModMenuDisplay()
                 break;
             case 7:
                 NpcControlMenuDisplay(); 
-                break;
+                break;              
             case 8: 
                 FlagsEditorDisplay(); 
                 break;
             case 9: 
                 CalendarEditorDisplay(); 
                 return;
-			case 10: 
+	    case 10: 
                 CutinTestDisplay(); 
                 return;	
-			case 11: 
+	    case 11: 
                 FontTestMenu();	
-				break;
-            case 12: 
+		break;
+	    case 12: 
+                ParticleTest();	
+		break;
+	    case 13: 
+                EditEnviroment();	
+		break;                
+            case 14: 
                 CallOriginalSquareMenu();
                 break;
-            case 13:
+            case 15:
                 AboutDialogDisplay();
                 break;
         }
@@ -2815,4 +2824,186 @@ void ParticleTest()
         }
     }
 
+}
+
+
+//Scenelights just seem to be the basic params you can find 
+//in GFS and GMD materials but applicable to every object in the scene.
+//I.E Ambient (AMB) Diffuse (DIFF) and Specular (SPEC).
+//Each function to control these scenelights has 4 params, 
+//the first 3 are Hue Saturation and Lightness (standard HSL colors)
+//and the last one is time, 0 is instant while 60 is a one-second fade in.
+//The scenelight commands basically override the ENV file temporarily,
+//for example you can turn Mementos into a stark white like Maruki's version
+//despite the ENV making everything reddish
+
+//Fog isn't used that agressively in the game, or at least changed that much.
+//The only real instances of fog commands being used are in Sae's dark room to
+//obscure the distance (Scenelights are also used to make the walls dark)
+//The set fog command has 6 params, the first two being "Near" and "Far" clip.
+//I'm not SURE what these do, but from testing they seem to be the starting 
+//ranges and radius of the fog. The next 3 are similar to scenelight controls,
+//standard Hue Saturation Lightness, however in this case there's also Alpha,
+//so it's HSLA coloring. The last param, like Scenelight, is time to fade in.
+
+//I noticed setting the fog in Shibuya Central Street at night while it's raining
+//has this weird bug with the Near And Far clip that makes the fog invert and start
+//from joker's position and fade off outwards. I'll need to test how rain changes
+//the fog conditions.
+
+
+void PrintScenelights()
+{
+	PUTS( " " );
+    PUTS( "Scenelight Params:" );
+	PUTS( " " );
+    
+	PUTS( "- Ambient -" );    
+	PUTS( "Hue:" );
+	PUT( FLD_GET_SCNLIGHT_AMB_H() );
+	PUTS( "Saturation:" );
+	PUT( FLD_GET_SCNLIGHT_AMB_S() );
+	PUTS( "Lightness:" );
+	PUT( FLD_GET_SCNLIGHT_AMB_L() );
+	PUTS( " " );
+    
+	PUTS( "- Diffuse -" );    
+	PUTS( "Hue:" );
+	PUT( FLD_GET_SCNLIGHT_DIFF_H() );
+	PUTS( "Saturation:" );
+	PUT( FLD_GET_SCNLIGHT_DIFF_S() );
+	PUTS( "Lightness:" );
+	PUT( FLD_GET_SCNLIGHT_DIFF_L() );
+	PUTS( " " );    
+    
+	PUTS( "- Specular -" );    
+	PUTS( "Hue:" );
+	PUT( FLD_GET_SCNLIGHT_SPEC_H() );
+	PUTS( "Saturation:" );
+	PUT( FLD_GET_SCNLIGHT_SPEC_S() );
+	PUTS( "Lightness:" );
+	PUT( FLD_GET_SCNLIGHT_SPEC_L() );
+	PUTS( " " );   
+}
+
+void PrintFog()
+{
+	PUTS( " " );
+    PUTS( "Fog Params:" );
+	PUTS( " " );
+    
+	PUTS( "Near Clip:" );
+	PUT( FLD_GET_FOG_NEAR_CLIP() );
+	PUTS( "Far Clip:" );
+	PUT( FLD_GET_FOG_FAR_CLIP() );
+	PUTS( "Hue:" );
+	PUT( FLD_GET_FOG_HUE() );
+	PUTS( "Saturation:" );
+	PUT( FLD_GET_FOG_SATURATION() );       
+	PUTS( "Lightness:" );
+	PUT( FLD_GET_FOG_LUMINANCE() );  
+	PUTS( "Alpha:" );
+	PUT( FLD_GET_FOG_ALPHA() );      
+}
+
+void SetHSL(int ADSChoice)
+{
+    DisplayMessagePrompt( HueDlg );
+    int Hue = SelectNumber( 3 );
+    DisplayMessagePrompt( SatDlg );
+    int Saturation = SelectNumber( 3 );
+    DisplayMessagePrompt( LumDlg );
+    int Lightness = SelectNumber( 3 );
+    switch ( ADSChoice )
+    {
+        case 0:                
+            FLD_SET_SCNLIGHT_AMB(Hue,Saturation,Lightness,0);
+            return;
+        case 1:                
+            FLD_SET_SCNLIGHT_DIFF(Hue,Saturation,Lightness,0);
+            return;
+        case 2:                
+            FLD_SET_SCNLIGHT_SPEC(Hue,Saturation,Lightness,0);
+            return;            
+    }    
+}
+
+void EditEnviroment()
+{
+    while ( true )
+    {
+        int selection = SEL_GENERIC( -1, EnviromentEditor );
+        switch ( selection )
+        {
+            case -1:
+                return;
+            case 0:                
+                FLD_SET_SCNLIGHT_AMB(255,255,255,0);
+                FLD_SET_SCNLIGHT_DIFF(255,255,255,0);
+                FLD_SET_SCNLIGHT_SPEC(255,255,255,0);
+                return;                
+            case 1:                
+                PrintScenelights();
+                return;
+            case 2:
+                SetHSL(0);
+                return;    
+            case 3:
+                SetHSL(1);
+                return;
+            case 4:
+                SetHSL(2);
+                return;    
+            case 5:
+                PrintFog();
+                return;
+            case 6:
+                float CCFogNearClip = SelectFloatPrompt( NearClipDlg );
+                if ( CCFogNearClip != -1 )
+                {
+                    FLD_SET_FOG( CCFogNearClip, FLD_GET_FOG_FAR_CLIP(), FLD_GET_FOG_HUE(), FLD_GET_FOG_SATURATION(), FLD_GET_FOG_LUMINANCE(), FLD_GET_FOG_ALPHA(), 0 );
+                }                    
+                return;
+            case 7:
+                float CCFogFarClip = SelectFloatPrompt( FarClipDlg );
+                if ( CCFogFarClip != -1 )
+                {
+                    FLD_SET_FOG( FLD_GET_FOG_NEAR_CLIP(), CCFogFarClip, FLD_GET_FOG_HUE(), FLD_GET_FOG_SATURATION(), FLD_GET_FOG_LUMINANCE(), FLD_GET_FOG_ALPHA(), 0 );
+                }                    
+                return;
+            case 8:
+                DisplayMessagePrompt( HueDlg );
+                int CCFogHue = SelectNumber( 3 );
+                if ( CCFogHue != -1 )
+                {
+                    FLD_SET_FOG( FLD_GET_FOG_NEAR_CLIP(), FLD_GET_FOG_FAR_CLIP(), CCFogHue, FLD_GET_FOG_SATURATION(), FLD_GET_FOG_LUMINANCE(), FLD_GET_FOG_ALPHA(), 0 );
+                }                    
+                return;
+            case 9:
+                DisplayMessagePrompt( SatDlg );
+                int CCFogSat = SelectNumber( 3 );
+                if ( CCFogSat != -1 )
+                {
+                    FLD_SET_FOG( FLD_GET_FOG_NEAR_CLIP(), FLD_GET_FOG_FAR_CLIP(), FLD_GET_FOG_HUE(), CCFogSat, FLD_GET_FOG_LUMINANCE(), FLD_GET_FOG_ALPHA(), 0 );
+                }                    
+                return;
+            case 10:
+                DisplayMessagePrompt( LumDlg );
+                int CCFogLum = SelectNumber( 3 );
+                if ( CCFogLum != -1 )
+                {
+                    FLD_SET_FOG( FLD_GET_FOG_NEAR_CLIP(), FLD_GET_FOG_FAR_CLIP(), FLD_GET_FOG_HUE(), FLD_GET_FOG_SATURATION(), CCFogLum, FLD_GET_FOG_ALPHA(), 0 );
+                }                    
+                return;
+            case 11:
+                DisplayMessagePrompt( AlpDlg );
+                int CCFogAlp = SelectNumber( 3 );
+                if ( CCFogAlp != -1 )
+                {
+                    FLD_SET_FOG( FLD_GET_FOG_NEAR_CLIP(), FLD_GET_FOG_FAR_CLIP(), FLD_GET_FOG_HUE(), FLD_GET_FOG_SATURATION(), FLD_GET_FOG_LUMINANCE(), CCFogAlp, 0 );
+                }                    
+                return;                
+        }
+        
+    }
 }

--- a/ModMenu.msg
+++ b/ModMenu.msg
@@ -1411,3 +1411,71 @@ Set the particles's speed.[n](press Circle to end)[n]Default is 10.[w][e]
 
 [dlg AlphaParticle]
 Set the particles's opacity.[n](press Circle to end)[n]Default is 10.[w][e]
+
+[sel EnviromentEditor]
+[s]Set all Scenelights to White[f 4 26 0 373][e]
+[s]Print Scenelights to TTY[f 4 26 1 374][e]
+[s]Set Ambient Scenelight[f 4 26 2 375][e]
+[s]Set Diffuse Scenelight[f 4 26 3 376][e]
+[s]Set Specular Scenelight[f 4 26 4 377][e]
+[s]Print Current Fog Params to TTY[f 4 26 5 378][e]
+[s]Set Near Clip[f 4 26 6 379][e]
+[s]Set Far Clip[f 4 26 7 380][e]
+[s]Set Fog Hue[f 4 26 8 381][e]
+[s]Set Fog Saturation[f 4 26 9 382][e]
+[s]Set Fog Lightness[f 4 26 10 383][e]
+[s]Set Fog Alpha[f 4 26 11 384][e]
+
+[dlg GENERIC_HELP_373]
+[s]Set all Scenelight data on[n]the current field to 255.[e]
+
+[dlg GENERIC_HELP_374]
+[s]Print all Scenelight data on[n]the current field to the TTY Log.[e]
+
+[dlg GENERIC_HELP_375]
+[s]Set the HSL Values for the[n]Ambient Scenelight.[e]
+
+[dlg GENERIC_HELP_376]
+[s]Set the HSL Values for the[n]Diffuse Scenelight.[e]
+
+[dlg GENERIC_HELP_377]
+[s]Set the HSL Values for the[n]Specular Scenelight.[e]
+
+[dlg GENERIC_HELP_378]
+[s]Print all fog params on[n]the current field to the TTY Log.[e]
+
+[dlg GENERIC_HELP_379]
+[s]Set the starting[n]location for the fog.[e]
+
+[dlg GENERIC_HELP_380]
+[s]Set the starting[n]radius for the fog.[e]
+
+[dlg GENERIC_HELP_381]
+[s]Set the current fog's Hue.[e]
+
+[dlg GENERIC_HELP_382]
+[s]Set the current fog's Saturation.[e]
+
+[dlg GENERIC_HELP_383]
+[s]Set the current fog's Lightness.[e]
+
+[dlg GENERIC_HELP_384]
+[s]Set the current fog's Opacity.[e]
+
+[dlg HueDlg]
+Set Hue to a 3 digit number. (Max 255)[w][e]
+
+[dlg SatDlg]
+Set Saturation to a 3 digit number. (Max 255)[w][e]
+
+[dlg LumDlg]
+Set Lightness to a 3 digit number. (Max 255)[w][e]
+
+[dlg AlpDlg]
+Set Opacity to a 3 digit number. (Max 255)[w][e]
+
+[dlg NearClipDlg]
+Set the fog's Near Clip[n](press Circle to end)[w][e]
+
+[dlg FarClipDlg]
+Set the fog's Near Clip[n](press Circle to end)[w][e]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Persona 5 Mod Menu
-## Added Features in Fork
-- Preliminary EPL Support 
 
 **Custom scripts for Persona 5 that replace the square button function with a fully featured trainer**
 ![Image of the menu ingame](https://cdn.discordapp.com/attachments/428021649246388224/447597680018063372/unknown.png)


### PR DESCRIPTION
-Adds commands to adjust Fog and Scenelights ingame, normally relegated to editing ENV files directly.
-Fixes issue with case switch that prevented EPL Preview from being selected in the first place.


![Screenshot_10](https://user-images.githubusercontent.com/21024014/106685969-8160bd80-6597-11eb-9c49-c3c9581f972a.png)
